### PR TITLE
Update workflow name and workspace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: Generate workflow load
+
 on:
   workflow_dispatch:
   
@@ -17,6 +19,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: execute test
         run: |
-          chmod +x /home/runner/_work/actions-load-test/actions-load-test/sr/test-script.sh
-          ./sr/test-script.sh
-          
+          chmod +x $GITHUB_WORKSPACE/sr/test-script.sh
+          $GITHUB_WORKSPACE/sr/test-script.sh


### PR DESCRIPTION
This seems to be required to enable the workflow after recreating it on the load test env. 

- had to add a name for the workflow_dispatch to become available in the UI and the API
- the fixed path gave issues on the load env runner
